### PR TITLE
Allow customisation of the default CSV options

### DIFF
--- a/README.md
+++ b/README.md
@@ -205,6 +205,18 @@ def index
 end
 ```
 
+### CSV configuration
+
+To configure how the CSV output is formatted you can define a configure block, like so:
+
+```ruby
+CsvShaper.configure do |config|
+  config.col_sep = "\t"
+  config.write_headers = false
+end
+
+```
+
 ##### Hat tips
 
 * [Jbuilder](https://github.com/rails/jbuilder/) for inspiration for the DSL

--- a/README.md
+++ b/README.md
@@ -231,6 +231,8 @@ end
 
 ```
 
+If you're using Rails you can put this in an initializer.
+
 ### Contributing
 
 1. Fork it

--- a/README.md
+++ b/README.md
@@ -228,8 +228,10 @@ CsvShaper.configure do |config|
   config.col_sep = "\t"
   config.write_headers = false
 end
-
 ```
+
+Inside the block you can pass any of the standard library [CSV DEFAULT_OPTIONS](http://ruby-doc.org/stdlib-1.9.2/libdoc/csv/rdoc/CSV.html#DEFAULT_OPTIONS), as well as a `write_headers` option (default: `true`).
+Setting this to `false` will exclude the headers from the final CSV output.
 
 If you're using Rails you can put this in an initializer.
 

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ Annotated source: http://paulspringett.github.com/csv_shaper/
 ### Example Usage
 
 ```ruby
-csv_string = CsvShaper::Shaper.encode do |csv|
+csv_string = CsvShaper.encode do |csv|
   csv.header :name, :age, :gender, :pet_names
   
   csv.rows @users do |csv, user|

--- a/lib/csv_shaper.rb
+++ b/lib/csv_shaper.rb
@@ -5,6 +5,7 @@ require 'csv_shaper/version'
 require 'csv_shaper/header'
 require 'csv_shaper/row'
 require 'csv_shaper/encoder'
+require 'csv_shaper/config'
 require 'csv_shaper/shaper'
 
 module CsvShaper
@@ -13,6 +14,10 @@ module CsvShaper
   # Shortcut the encode method
   def self.encode(&block)
     CsvShaper::Shaper.encode(&block)
+  end
+
+  def self.configure(&block)
+    CsvShaper::Shaper.configure(&block)
   end
 end
 

--- a/lib/csv_shaper.rb
+++ b/lib/csv_shaper.rb
@@ -9,6 +9,11 @@ require 'csv_shaper/shaper'
 
 module CsvShaper
   class MissingHeadersError < StandardError; end
+
+  # Shortcut the encode method
+  def self.encode(&block)
+    CsvShaper::Shaper.encode(&block)
+  end
 end
 
 require "csv_shaper_template" if defined?(ActionView::Template)

--- a/lib/csv_shaper/config.rb
+++ b/lib/csv_shaper/config.rb
@@ -1,0 +1,53 @@
+require 'csv'
+
+module CsvShaper
+  # Config
+  # Configure the standard CSV default options
+  # as well the option to output the header row
+  class Config
+    attr_reader :options
+
+    def initialize
+      @options = {}
+      yield self if block_given?
+    end
+
+    # Public: set options where the method name
+    # matches a key
+    def method_missing(meth, value)
+      meth = sanitize_setter_method(meth)
+
+      if defaults.key?(meth)
+        @options[meth] = value
+      else
+        super
+      end
+    end
+
+    def respond_to?(meth)
+      meth = sanitize_setter_method(meth)
+      defaults.has_key?(meth)
+    end
+
+    private
+
+    # Internal: removes the equals from the end of the
+    # method name
+    #
+    # `meth` - Symbol of the method of sanitize
+    #
+    # Returns a Symbol
+    def sanitize_setter_method(meth)
+      meth = meth.to_s.gsub('=', '')
+      meth.to_sym
+    end
+
+    # Internal: default CSV options, plus a write headers
+    # option, to pass to #to_csv
+    #
+    # Returns a Hash
+    def defaults
+      @defaults ||= CSV::DEFAULT_OPTIONS.dup.merge(write_headers: true)
+    end
+  end
+end

--- a/lib/csv_shaper/config.rb
+++ b/lib/csv_shaper/config.rb
@@ -26,7 +26,7 @@ module CsvShaper
 
     def respond_to?(meth)
       meth = sanitize_setter_method(meth)
-      defaults.has_key?(meth)
+      defaults.key?(meth)
     end
 
     private

--- a/lib/csv_shaper/encoder.rb
+++ b/lib/csv_shaper/encoder.rb
@@ -27,11 +27,15 @@ module CsvShaper
       end
 
       table = CSV::Table.new(rows)
-      table.to_csv
+      table.to_csv(options)
     end
     
     private
-    
+
+    def options
+      CsvShaper::Shaper.config.try(:options) || {}
+    end
+
     # Internal: make use of `CSV#values_at` to pad out the
     # cells into the correct columns for the headers
     #

--- a/lib/csv_shaper/encoder.rb
+++ b/lib/csv_shaper/encoder.rb
@@ -33,7 +33,7 @@ module CsvShaper
     private
 
     def options
-      CsvShaper::Shaper.config.try(:options) || {}
+      CsvShaper::Shaper.config && CsvShaper::Shaper.config.options || {}
     end
 
     # Internal: make use of `CSV#values_at` to pad out the

--- a/lib/csv_shaper/shaper.rb
+++ b/lib/csv_shaper/shaper.rb
@@ -2,6 +2,7 @@ module CsvShaper
   # Shaper
   # Core CsvShaper class. Delegates header and row generating.
   class Shaper
+    cattr_accessor :config
     attr_reader :header, :rows
     
     def initialize
@@ -72,5 +73,11 @@ module CsvShaper
     def to_csv
       Encoder.new(@header, @rows).to_csv
     end
+
+    # Public: Create an instance of the config and cache it
+    # for reference by the Encoder later
+    def self.configure(&block)
+       self.config ||= CsvShaper::Config.new(&block)
+     end
   end
 end

--- a/lib/csv_shaper/shaper.rb
+++ b/lib/csv_shaper/shaper.rb
@@ -2,8 +2,11 @@ module CsvShaper
   # Shaper
   # Core CsvShaper class. Delegates header and row generating.
   class Shaper
-    cattr_accessor :config
     attr_reader :header, :rows
+    
+    class << self
+      attr_accessor :config
+    end
     
     def initialize
       @rows = []
@@ -77,7 +80,7 @@ module CsvShaper
     # Public: Create an instance of the config and cache it
     # for reference by the Encoder later
     def self.configure(&block)
-       self.config ||= CsvShaper::Config.new(&block)
+       @config ||= CsvShaper::Config.new(&block)
      end
   end
 end

--- a/spec/config_spec.rb
+++ b/spec/config_spec.rb
@@ -1,0 +1,11 @@
+require 'spec_helper'
+
+describe CsvShaper::Config do
+  it "should assign options to config" do
+    config = CsvShaper::Config.new do |c|
+      c.write_headers = false
+      c.col_sep = '\t'
+    end
+    config.options.should eq({ write_headers: false, col_sep: '\t' })
+  end  
+end

--- a/spec/config_spec.rb
+++ b/spec/config_spec.rb
@@ -1,11 +1,30 @@
 require 'spec_helper'
 
 describe CsvShaper::Config do
-  it "should assign options to config" do
-    config = CsvShaper::Config.new do |c|
+  let(:config) {
+    CsvShaper::Config.new do |c|
       c.write_headers = false
-      c.col_sep = '\t'
+      c.col_sep = "\t"
     end
-    config.options.should eq({ write_headers: false, col_sep: '\t' })
-  end  
+  }
+  
+  it "should assign options to config" do
+    config.options.should eq({ write_headers: false, col_sep: "\t" })
+  end
+  
+  it "should exclude the headers if specified" do
+    CsvShaper::Shaper.config = config
+    
+    shaper = CsvShaper::Shaper.new do |csv|
+      csv.headers :name, :age, :gender
+      
+      csv.row do |csv|
+        csv.cell :name, 'Paul'
+        csv.cell :age, '27'
+        csv.cell :gender, 'Male'
+      end
+    end
+    
+    shaper.to_csv.should eq "Paul\t27\tMale\n"
+  end
 end

--- a/spec/csv_shaper_spec.rb
+++ b/spec/csv_shaper_spec.rb
@@ -16,4 +16,13 @@ describe CsvShaper::Shaper do
     csv = CsvShaper::Shaper.new
     csv.should respond_to(:to_csv)
   end
+
+  it "should provide a shortcut to the encode method" do
+    CsvShaper.should respond_to(:encode)
+
+    CsvShaper.encode do |csv|
+      csv.headers :foo
+      csv.should be_instance_of(CsvShaper::Shaper)
+    end
+  end
 end

--- a/spec/encoder_spec.rb
+++ b/spec/encoder_spec.rb
@@ -4,6 +4,12 @@ require 'fixtures/user'
 describe CsvShaper::Encoder do
   let(:user) { User.new(name: 'Paul', age: 27, gender: 'Male') }
   
+  let(:config) {
+    CsvShaper::Config.new do |c|
+      c.write_headers = true
+    end
+  }
+  
   it "should raise an exception if the headers are missing" do
     expect {
       CsvShaper::Encoder.new(nil)
@@ -30,6 +36,7 @@ describe CsvShaper::Encoder do
   }
   
   it "should encode a Shaper instance to a CSV string" do
+    CsvShaper::Shaper.config = config
     encoder = CsvShaper::Encoder.new(csv.header, csv.rows)
     encoder.to_csv.should eq("Full name,Sex,Age\nPaul,Male,27\nBob,Male,31\nJane,Female,23\n,,81\n")
   end


### PR DESCRIPTION
Config block allows the following config:
- All standard default CSV options
- A `write_headers` option to include the headers in the output or not

TODO:
- Complete detailed docs (maybe it's time for a Wiki?!)
- Add a Changelog
- Write some tests for the config (should set options and apply them
