### PR TITLE
Fix Row#cell nil assignment bug

### DIFF
--- a/lib/csv_shaper/row.rb
+++ b/lib/csv_shaper/row.rb
@@ -60,7 +60,7 @@ module CsvShaper
     def cell(column, value = nil)
       column = column.to_sym
       
-      if @model && value.nil?
+      if @model && @model.respond_to?(column) && value.nil?
         @cells[column] = @model.send(column)
       else
         @cells[column] = value

--- a/spec/row_spec.rb
+++ b/spec/row_spec.rb
@@ -22,4 +22,24 @@ describe CsvShaper::Row do
       csv.should be_kind_of(CsvShaper::Row)
     }
   end
+  
+  describe "cells" do
+    it "should send parse an attribute of the model" do
+      row = CsvShaper::Row.new(user, :gender)
+      row.cell :name
+      row.cells.should eq({ name: 'Paul', gender: 'Male' })
+    end
+    
+    it "should send assign an unrelated value" do
+      row = CsvShaper::Row.new(user, :gender)
+      row.cell :foo, 'bar'
+      row.cells.should eq({ foo: 'bar', gender: 'Male' })
+    end
+    
+    it "ignore nil values passed" do
+      row = CsvShaper::Row.new(user, :gender)
+      row.cell :foo, nil
+      row.cells.should eq({ foo: nil, gender: 'Male' })
+    end
+  end
 end


### PR DESCRIPTION
Fixed bug where passed a nil value to Row#cell would be treated as though
there was no second value
