### PR TITLE
Allow local customisation of CSV options.

### DIFF
--- a/README.md
+++ b/README.md
@@ -235,6 +235,14 @@ Setting this to `false` will exclude the headers from the final CSV output.
 
 If you're using Rails you can put this in an initializer.
 
+To configure CSV output locally to change global behavior you can define a configure hash, like so:
+
+```ruby
+CsvShaper.encode col_sep: "\t" do |csv|
+  ...
+end
+```
+
 ### Contributing
 
 1. Fork it

--- a/lib/csv_shaper.rb
+++ b/lib/csv_shaper.rb
@@ -12,8 +12,8 @@ module CsvShaper
   class MissingHeadersError < StandardError; end
 
   # Shortcut the encode method
-  def self.encode(&block)
-    CsvShaper::Shaper.encode(&block)
+  def self.encode(options = {}, &block)
+    CsvShaper::Shaper.encode(options, &block)
   end
 
   def self.configure(&block)

--- a/lib/csv_shaper/encoder.rb
+++ b/lib/csv_shaper/encoder.rb
@@ -21,19 +21,25 @@ module CsvShaper
     # a CSV String
     #
     # Returns a String
-    def to_csv
+    def to_csv(local_config = nil)
+      csv_options = options.merge(local_options(local_config))
+      
       rows = padded_rows.map do |data|
         CSV::Row.new(@header.mapped_columns, data, false)
       end
-
+      
       table = CSV::Table.new(rows)
-      table.to_csv(options)
+      table.to_csv(csv_options)
     end
     
     private
 
     def options
       CsvShaper::Shaper.config && CsvShaper::Shaper.config.options || {}
+    end
+    
+    def local_options(local_config)
+      local_config && local_config.options || {}
     end
 
     # Internal: make use of `CSV#values_at` to pad out the

--- a/lib/csv_shaper/shaper.rb
+++ b/lib/csv_shaper/shaper.rb
@@ -8,8 +8,9 @@ module CsvShaper
       attr_accessor :config
     end
     
-    def initialize
+    def initialize(options = {})
       @rows = []
+      local_configuration(options)
       yield self if block_given?
     end
     
@@ -28,8 +29,8 @@ module CsvShaper
     # ```
     #
     # Returns a String
-    def self.encode
-      new.tap { |shaper| yield shaper }.to_csv
+    def self.encode(options = {})
+      new(options).tap { |shaper| yield shaper }.to_csv
     end
     
     # Public: creates a header row for the CSV
@@ -74,13 +75,21 @@ module CsvShaper
     #
     # Returns a String
     def to_csv
-      Encoder.new(@header, @rows).to_csv
+      Encoder.new(@header, @rows).to_csv(@local_config)
     end
 
     # Public: Create an instance of the config and cache it
     # for reference by the Encoder later
     def self.configure(&block)
-       @config ||= CsvShaper::Config.new(&block)
-     end
+      @config ||= CsvShaper::Config.new(&block)
+    end
+    
+    private
+    
+    def local_configuration(options = {})
+      @local_config = CsvShaper::Config.new do |csv|
+        options.each_pair { |k, v| csv.send("#{k}=", v) }
+      end
+    end
   end
 end

--- a/spec/config_spec.rb
+++ b/spec/config_spec.rb
@@ -27,4 +27,20 @@ describe CsvShaper::Config do
     
     shaper.to_csv.should eq "Paul\t27\tMale\n"
   end
+  
+  it "should allow change configuration locally" do
+    CsvShaper::Shaper.config = config
+    
+    shaper = CsvShaper::Shaper.new col_sep: "," do |csv|
+      csv.headers :name, :age, :gender
+      
+      csv.row do |csv|
+        csv.cell :name, 'Paul'
+        csv.cell :age, '27'
+        csv.cell :gender, 'Male'
+      end
+    end
+    
+    shaper.to_csv.should eq "Paul,27,Male\n"
+  end
 end


### PR DESCRIPTION
It's useful when someone needs to use several CSV options across an application. 
