### PR TITLE
Add inflector option

### DIFF
--- a/lib/csv_shaper/config.rb
+++ b/lib/csv_shaper/config.rb
@@ -4,7 +4,10 @@ module CsvShaper
   # Config
   # Configure the standard CSV default options
   # as well the option to output the header row
+
   class Config
+    CUSTOM_DEFAULT_OPTIONS = { header_inflector: :humanize }
+
     attr_reader :options
 
     def initialize
@@ -47,7 +50,9 @@ module CsvShaper
     #
     # Returns a Hash
     def defaults
-      @defaults ||= CSV::DEFAULT_OPTIONS.dup.merge(write_headers: true)
+      @defaults ||= CSV::DEFAULT_OPTIONS.dup.
+        merge(write_headers: true).
+        merge(CUSTOM_DEFAULT_OPTIONS)
     end
   end
 end

--- a/lib/csv_shaper/encoder.rb
+++ b/lib/csv_shaper/encoder.rb
@@ -12,34 +12,39 @@ module CsvShaper
       if header.nil?
         raise MissingHeadersError, 'you must define some headers using csv.headers ...'
       end
-      
+
       @header = header
       @rows = rows
     end
-    
+
     # Public: converts the Shaper mapped headers and rows into
     # a CSV String
     #
     # Returns a String
     def to_csv(local_config = nil)
       csv_options = options.merge(local_options(local_config))
-      
+
       rows = padded_rows.map do |data|
         CSV::Row.new(@header.mapped_columns, data, false)
       end
-      
+
       table = CSV::Table.new(rows)
+      csv_options.except!(*custom_options.keys)
       table.to_csv(csv_options)
     end
-    
+
     private
 
     def options
       CsvShaper::Shaper.config && CsvShaper::Shaper.config.options || {}
     end
-    
+
     def local_options(local_config)
       local_config && local_config.options || {}
+    end
+
+    def custom_options
+      CsvShaper::Config::CUSTOM_DEFAULT_OPTIONS
     end
 
     # Internal: make use of `CSV#values_at` to pad out the
@@ -50,7 +55,7 @@ module CsvShaper
       rows = @rows.map do |row|
         CSV::Row.new(row.cells.keys, row.cells.values)
       end
-      
+
       table = CSV::Table.new(rows)
       table.values_at(*@header.columns)
     end

--- a/lib/csv_shaper/header.rb
+++ b/lib/csv_shaper/header.rb
@@ -2,13 +2,13 @@ module CsvShaper
   # Header
   # Handles creating and mapping of the headers
   # Examples:
-  # ``` 
+  # ```
   # # assign the headers from the attributes of a class
   # csv.headers User
-  # 
+  #
   # # assigns headers normally
   # csv.headers :name, :age, :location
-  # 
+  #
   # # pass a block
   # csv.headers do |csv|
   #   csv.columns :name, :age, :location
@@ -16,11 +16,12 @@ module CsvShaper
   # end
   # ```
   class Header
-    attr_reader :klass, :mappings, :mapped_columns
+    attr_reader :klass, :mappings, :mapped_columns, :inflector
 
     def initialize(*args)
       @mappings = {}
       @columns = []
+      @header_inflector = CsvShaper::Shaper.config.options[:header_inflector]
 
       if block_given?
         yield self
@@ -32,7 +33,7 @@ module CsvShaper
         end
       end
     end
-    
+
     # Public: serves as the getter and setter for the Array
     # of Symbol column names. Union join the existing column
     # names with those passed
@@ -46,7 +47,7 @@ module CsvShaper
     def columns(*args)
       @columns = @columns | args.map(&:to_sym)
     end
-    
+
     # Public: Define mappings of the Symbol column names
     # to nicer, human names
     # Example:
@@ -57,19 +58,31 @@ module CsvShaper
     #          and the value is the human readable value
     #
     # Returns a Hash of mappings
-    def mappings(hash = {}) 
+    def mappings(hash = {})
       @mappings.merge!(hash)
     end
-    
+
+    # Public: Convert column names, default inflector is :humanize
+    # Example:
+    # ```
+    # header.inflector :titleize
+    # ```
+    # `:titleize` - one of ruby inflectors
+    def inflector(inflector = @header_inflector)
+      @header_inflector = inflector
+    end
+
     # Public: converts columns and mappings into mapped columns
     # ready for encoding. If a mapped value is found that is used,
-    # else the Symbol column name is humanized
+    # else the Symbol column name is humanized by default or can be specified
+    # with header_inflector option
     #
     # Returns an Array of Strings
     def mapped_columns
       @columns.map do |column|
-        @mappings[column] || column.to_s.humanize
+        @mappings[column] || column.to_s.send(@header_inflector)
       end
     end
+
   end
 end

--- a/lib/csv_shaper/shaper.rb
+++ b/lib/csv_shaper/shaper.rb
@@ -3,17 +3,17 @@ module CsvShaper
   # Core CsvShaper class. Delegates header and row generating.
   class Shaper
     attr_reader :header, :rows
-    
+
     class << self
       attr_accessor :config
     end
-    
+
     def initialize(options = {})
       @rows = []
       local_configuration(options)
       yield self if block_given?
     end
-    
+
     # Public: creates a new instance of Shaper taps it with
     # with the given block and encodes it to a String of CSV data
     # Example:
@@ -25,14 +25,14 @@ module CsvShaper
     # end
     #
     # puts data
-    # => "Name,Age,Gender\n'Joe Bloggs',25,'M'\n'John Smith',34,'M'" 
+    # => "Name,Age,Gender\n'Joe Bloggs',25,'M'\n'John Smith',34,'M'"
     # ```
     #
     # Returns a String
     def self.encode(options = {})
       new(options).tap { |shaper| yield shaper }.to_csv
     end
-    
+
     # Public: creates a header row for the CSV
     # This is delegated to the Header class
     # see header.rb for usage examples
@@ -41,7 +41,7 @@ module CsvShaper
     def headers(*args, &block)
       @header = Header.new(*args, &block)
     end
-    
+
     # Public: adds a row to the CSV
     # This is delegated to the Row class
     # See row.rb for usage examples
@@ -50,7 +50,7 @@ module CsvShaper
     def row(*args, &block)
       @rows.push Row.new(*args, &block)
     end
-    
+
     # Public: adds several rows to the CSV
     #
     # `collection` - an Enumerable of objects to be passed to #row
@@ -58,7 +58,7 @@ module CsvShaper
     # Returns an updated Array of Row objects
     def rows(collection = nil, &block)
       return @rows if collection.nil?
-      
+
       unless collection.respond_to?(:each)
         raise ArgumentError, 'csv.rows only accepts Enumerable object (that respond to #each). Use csv.row for a single object.'
       end
@@ -83,9 +83,9 @@ module CsvShaper
     def self.configure(&block)
       @config ||= CsvShaper::Config.new(&block)
     end
-    
+
     private
-    
+
     def local_configuration(options = {})
       @local_config = CsvShaper::Config.new do |csv|
         options.each_pair { |k, v| csv.send("#{k}=", v) }

--- a/spec/config_spec.rb
+++ b/spec/config_spec.rb
@@ -5,42 +5,59 @@ describe CsvShaper::Config do
     CsvShaper::Config.new do |c|
       c.write_headers = false
       c.col_sep = "\t"
+      c.header_inflector = :titleize
     end
   }
-  
+
   it "should assign options to config" do
-    config.options.should eq({ write_headers: false, col_sep: "\t" })
+    config.options.should eq({ write_headers: false, col_sep: "\t", header_inflector: :titleize })
   end
-  
+
   it "should exclude the headers if specified" do
     CsvShaper::Shaper.config = config
-    
+
     shaper = CsvShaper::Shaper.new do |csv|
       csv.headers :name, :age, :gender
-      
+
       csv.row do |csv|
         csv.cell :name, 'Paul'
         csv.cell :age, '27'
         csv.cell :gender, 'Male'
       end
     end
-    
+
     shaper.to_csv.should eq "Paul\t27\tMale\n"
   end
-  
+
   it "should allow change configuration locally" do
     CsvShaper::Shaper.config = config
-    
+
     shaper = CsvShaper::Shaper.new(col_sep: ",") do |csv|
       csv.headers :name, :age, :gender
-      
+
       csv.row do |csv|
         csv.cell :name, 'Paul'
         csv.cell :age, '27'
         csv.cell :gender, 'Male'
       end
     end
-    
+
     shaper.to_csv.should eq "Paul,27,Male\n"
+  end
+
+  it "should allow change inflector locally" do
+    CsvShaper::Shaper.config = config
+
+    shaper = CsvShaper::Shaper.new(col_sep: ",", write_headers: true, header_inflector: :titleize) do |csv|
+      csv.headers :full_name, :age, :gender
+
+      csv.row do |csv|
+        csv.cell :full_name, 'Paul'
+        csv.cell :age, '27'
+        csv.cell :gender, 'Male'
+      end
+    end
+
+    shaper.to_csv.should eq "Full Name,Age,Gender\nPaul,27,Male\n"
   end
 end

--- a/spec/header_spec.rb
+++ b/spec/header_spec.rb
@@ -2,35 +2,50 @@ require 'spec_helper'
 require 'fixtures/user'
 
 describe CsvShaper::Header do
+
+  before(:each) do
+    CsvShaper::Shaper.stub_chain(:config, :options).and_return({ header_inflector: :humanize})
+  end
+
   it "should accept and store a list of symbols" do
     header = CsvShaper::Header.new(:name, :age, :location)
-    
+
     header.columns.should eq [:name, :age, :location]
   end
-  
+
   it "should accept a Model and store it's attributes" do
     header = CsvShaper::Header.new(User)
-    
+
     header.columns.should eq [:name, :age, :gender]
   end
-  
+
   it "should accept a block with columns and mappings" do
     header = CsvShaper::Header.new do |csv|
       csv.columns :name, :age, :foo
       csv.mappings name: 'User name'
     end
-    
+
     header.columns.should eq [:name, :age, :foo]
     header.mapped_columns.should eq ['User name', 'Age', 'Foo']
   end
-  
+
+  it "should titleize column names according to the chosen inflector" do
+    header = CsvShaper::Header.new do |csv|
+      csv.columns :first_name, :full_age
+      csv.inflector :titleize
+    end
+
+    header.columns.should eq [:first_name, :full_age]
+    header.mapped_columns.should eq ['First Name', 'Full Age']
+  end
+
   it "should merge columns with a union join" do
     header = CsvShaper::Header.new(:name, :age, :location)
     header.columns :age, :gender
-    
+
     header.columns.should eq [:name, :age, :location, :gender]
   end
-  
+
   it "should merge mappings" do
     header = CsvShaper::Header.new do |csv|
       csv.columns :name, :age, :foo

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -2,6 +2,5 @@ require 'rspec'
 require 'csv_shaper'
 
 RSpec.configure do |config|
-  config.color_enabled = true
   config.formatter = 'documentation'
 end


### PR DESCRIPTION
For now you can specify inflector for header column:

Example:

``` ruby
csv.headers do |csv|
  csv.columns :name, :age, :location
  csv.mappings name: 'Full name', location: 'Region'
  csv.inflector :titleize
end
```

or

``` ruby
CsvShaper.configure do |config|
  config.header_inflector = :titleize
end
```

or

``` ruby
csv_string = CsvShaper::Shaper.encode(header_inflector: :titleize) do |csv|
  ...
end
```
