### PR TITLE
Ensure a config is always returned from CsvShaper::Shaper.config

### DIFF
--- a/lib/csv_shaper/shaper.rb
+++ b/lib/csv_shaper/shaper.rb
@@ -4,8 +4,12 @@ module CsvShaper
   class Shaper
     attr_reader :header, :rows
 
-    class << self
-      attr_accessor :config
+    def self.config
+      @config ||= Config.new
+    end
+
+    def self.config=(new_config)
+      @config = new_config
     end
 
     def initialize(options = {})

--- a/spec/config_spec.rb
+++ b/spec/config_spec.rb
@@ -13,6 +13,20 @@ describe CsvShaper::Config do
     expect(config.options).to eq({ write_headers: false, col_sep: "\t", header_inflector: :titleize })
   end
 
+  it "does not require setting up the config before generating a CSV file" do
+    shaper = CsvShaper::Shaper.new do |csv|
+      csv.headers :name, :age, :gender
+
+      csv.row do |csv|
+        csv.cell :name, 'Paul'
+        csv.cell :age, '27'
+        csv.cell :gender, 'Male'
+      end
+    end
+
+    expect(shaper.to_csv).to eq "Name,Age,Gender\nPaul,27,Male\n"
+  end
+
   it "should exclude the headers if specified" do
     CsvShaper::Shaper.config = config
 


### PR DESCRIPTION
If the config was not previously set up, `CsvShaper::Shaper.config` would return `nil` and break the header inflector's expectation that a config was always present. This ensures that a config object is returned if no config has been set already.

This fixes a regression introduced in v1.1.0.
