### PR TITLE
Output a header for an empty file with no rows

### DIFF
--- a/lib/csv_shaper/encoder.rb
+++ b/lib/csv_shaper/encoder.rb
@@ -27,6 +27,10 @@ module CsvShaper
         CSV::Row.new(@header.mapped_columns, data, false)
       end
 
+      if csv_options[:write_headers] && rows.empty?
+        rows << CSV::Row.new(@header.mapped_columns, [], true)
+      end
+
       table = CSV::Table.new(rows)
       csv_options.except!(*custom_options.keys)
       table.to_csv(csv_options)

--- a/spec/encoder_spec.rb
+++ b/spec/encoder_spec.rb
@@ -40,4 +40,10 @@ describe CsvShaper::Encoder do
     encoder = CsvShaper::Encoder.new(csv.header, csv.rows)
     expect(encoder.to_csv).to eq("Full name,Sex,Age\nPaul,Male,27\nBob,Male,31\nJane,Female,23\n,,81\n")
   end
+
+  it "should encode a Shaper instance with no rows to a CSV string" do
+    CsvShaper::Shaper.config = config
+    encoder = CsvShaper::Encoder.new(csv.header, [])
+    expect(encoder.to_csv).to eq("Full name,Sex,Age\n")
+  end
 end


### PR DESCRIPTION
This PR updates `CsvShaper::Encoder` to output a header row explicitly if no data rows have been added and `:write_headers` is `true`.