### PR TITLE
Avoid deprecation warnings on Rails 5 for accessing MIME types via constants

### DIFF
--- a/lib/csv_shaper_template.rb
+++ b/lib/csv_shaper_template.rb
@@ -17,7 +17,7 @@ end
 # Template handler for Rails
 class CsvShaperHandler
   cattr_accessor :default_format
-  self.default_format = Mime::CSV
+  self.default_format = Mime[:csv]
 
   # Expected `call` class method
   # Set response headers with filename


### PR DESCRIPTION
I've noticed that on my Rails 5 project I get deprecation warnings that I can trace to csv_shaper. 

This PR will fix those deprecation warnings. 