### PR TITLE
Expose Config object to Rails templates for template-specific configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -264,6 +264,12 @@ CsvShaper.encode(col_sep: "\t") do |csv|
 end
 ```
 
+To configure Rails template-specific CSV output, use the `config` method on the `csv` object:
+
+```ruby
+csv.config.col_sep = "\t"
+```
+
 ### Contributing
 
 1. Fork it

--- a/lib/csv_shaper.rb
+++ b/lib/csv_shaper.rb
@@ -21,4 +21,4 @@ module CsvShaper
   end
 end
 
-require "csv_shaper_template" if defined?(ActionView::Template)
+require "csv_shaper_handler" if defined?(ActionView::Template)

--- a/lib/csv_shaper_handler.rb
+++ b/lib/csv_shaper_handler.rb
@@ -1,0 +1,27 @@
+require 'csv_shaper_template'
+
+# CsvShaperHandler
+# Template handler for Rails
+class CsvShaperHandler
+  cattr_accessor :default_format
+  self.default_format = Mime[:csv]
+
+  # Expected `call` class method
+  # Set response headers with filename
+  # Primarily calls CsvShaperTemplate.encode, passing through the context (self)
+  def self.call(template)
+    %{
+      if ( controller.present? ) && !( defined?(ActionMailer) && defined?(ActionMailer::Base) && controller.is_a?(ActionMailer::Base) )
+        @filename ||= "\#{controller.action_name}.csv"
+        controller.response.headers["Content-Type"] ||= 'text/csv'
+        controller.response.headers['Content-Disposition'] = "attachment; filename=\\\"\#{@filename}\\\""
+      end
+
+      CsvShaperTemplate.encode(self) do |csv|
+        #{template.source}
+      end
+    }
+  end
+end
+
+ActionView::Template.register_template_handler :shaper, CsvShaperHandler

--- a/lib/csv_shaper_template.rb
+++ b/lib/csv_shaper_template.rb
@@ -11,30 +11,8 @@ class CsvShaperTemplate < CsvShaper::Shaper
     @context = context
     super()
   end
-end
 
-# CsvShaperHandler
-# Template handler for Rails
-class CsvShaperHandler
-  cattr_accessor :default_format
-  self.default_format = Mime[:csv]
-
-  # Expected `call` class method
-  # Set response headers with filename
-  # Primarily calls CsvShaperTemplate.encode, passing through the context (self)
-  def self.call(template)
-    %{
-      if ( controller.present? ) && !( defined?(ActionMailer) && defined?(ActionMailer::Base) && controller.is_a?(ActionMailer::Base) )
-        @filename ||= "\#{controller.action_name}.csv"
-        controller.response.headers["Content-Type"] ||= 'text/csv'
-        controller.response.headers['Content-Disposition'] = "attachment; filename=\\\"\#{@filename}\\\""
-      end
-
-      CsvShaperTemplate.encode(self) do |csv|
-        #{template.source}
-      end
-    }
+  def config
+    @local_config
   end
 end
-
-ActionView::Template.register_template_handler :shaper, CsvShaperHandler

--- a/spec/csv_shaper_template_spec.rb
+++ b/spec/csv_shaper_template_spec.rb
@@ -1,0 +1,42 @@
+require 'spec_helper'
+require "csv_shaper_template"
+
+describe CsvShaperTemplate do
+  it "should allow configuration via #config method" do
+    csv_string = CsvShaperTemplate.encode(double('context')) do |csv|
+      csv.config.write_headers = false
+      csv.config.col_sep = ';'
+
+      csv.headers :name, :age, :gender
+
+      csv.row do |csv|
+        csv.cell :name, 'Paul'
+        csv.cell :age, '27'
+        csv.cell :gender, 'Male'
+      end
+    end
+
+    expect(csv_string).to eq "Paul;27;Male\n"
+  end
+
+  it "should override global configuration with local configuration" do
+    CsvShaper::Shaper.config = CsvShaper::Config.new do |c|
+      c.write_headers = false
+      c.col_sep = "\t"
+    end
+
+    csv_string = CsvShaperTemplate.encode(double('context')) do |csv|
+      csv.config.col_sep = ','
+
+      csv.headers :name, :age, :gender
+
+      csv.row do |csv|
+        csv.cell :name, 'Paul'
+        csv.cell :age, '27'
+        csv.cell :gender, 'Male'
+      end
+    end
+
+    expect(csv_string).to eq "Paul,27,Male\n"
+  end
+end


### PR DESCRIPTION
Previously, there was no easy way to configuring CSV output on a template-specific level when rendering through Rails.  This PR exposes the local config object to Rails templates via a new `config` method.  I've updated the README, and added spec coverage for scenarios with and without existing global configuration.  

To add test coverage for the `CsvShaperTemplate` class, I broke it out into a separate file from `CsvShaperHandler`, to avoid depending on Action Pack for `Mime::CSV`