### PR TITLE
Fix deprecation warnings on Rails 6

### DIFF
--- a/lib/csv_shaper_handler.rb
+++ b/lib/csv_shaper_handler.rb
@@ -9,7 +9,7 @@ class CsvShaperHandler
   # Expected `call` class method
   # Set response headers with filename
   # Primarily calls CsvShaperTemplate.encode, passing through the context (self)
-  def self.call(template)
+  def self.call(template, source = nil)
     %{
       if ( controller.present? ) && !( defined?(ActionMailer) && defined?(ActionMailer::Base) && controller.is_a?(ActionMailer::Base) )
         @filename ||= "\#{controller.action_name}.csv"
@@ -18,7 +18,7 @@ class CsvShaperHandler
       end
 
       CsvShaperTemplate.encode(self) do |csv|
-        #{template.source}
+        #{source || template.source}
       end
     }
   end


### PR DESCRIPTION
This fixes a deprecation warning when used with Rails 6 (6.0.0.rc1)

```
DEPRECATION WARNING: Single arity template handlers are deprecated. Template handlers must
now accept two parameters, the view object and the source for the view object.
Change:
  >> CsvShaperHandler.call(template)
To:
  >> CsvShaperHandler.call(template, source)
```