### PR TITLE
Fix ruby 2.7 keyword arguments warning.

### DIFF
--- a/lib/csv_shaper/encoder.rb
+++ b/lib/csv_shaper/encoder.rb
@@ -33,7 +33,7 @@ module CsvShaper
 
       table = CSV::Table.new(rows)
       csv_options.except!(*custom_options.keys)
-      table.to_csv(csv_options)
+      table.to_csv(**csv_options)
     end
 
     private


### PR DESCRIPTION
Fixes ruby 2.7 keyword arguments warning
```
/repos/csv_shaper/lib/csv_shaper/encoder.rb:36: warning: Using the last argument as keyword parameters is deprecated; maybe ** should be added to the call
/.rbenv/versions/2.7.1/lib/ruby/2.7.0/csv/table.rb:369: warning: The called method `to_csv' is defined here
```