### PR TITLE
Fix Ruby 3.3 warning about requiring csv without dependency

### DIFF
--- a/csv_shaper.gemspec
+++ b/csv_shaper.gemspec
@@ -25,6 +25,7 @@ Gem::Specification.new do |gem|
   gem.version       = CsvShaper::VERSION
 
   gem.add_dependency 'activesupport', '>= 3.0.0'
+  gem.add_dependency 'csv' if Gem::Version.new(RUBY_VERSION) >= Gem::Version.new('3.3')
   gem.add_development_dependency 'rspec'
   gem.add_development_dependency 'rake'
 end


### PR DESCRIPTION
The csv library is moving to a "bundled" gem as of Ruby 3.4 (instead of "default"), so if you require it now without an explicit dependency with Ruby 3.3, you'll get a warning:
```
/Users/cgunther/.gem/ruby/3.3.1/gems/bootsnap-1.18.3/lib/bootsnap/load_path_cache/core_ext/kernel_require.rb:30: warning: /Users/chrisgunther/.rubies/ruby-3.3.1/lib/ruby/3.3.0/csv.rb was loaded from the standard library, but will no longer be part of the default gems since Ruby 3.4.0. Add csv to your Gemfile or gemspec. Also contact author of csv_shaper-1.3.2 to add csv into its gemspec.
```